### PR TITLE
Fixes for compilation of analysis skeleton

### DIFF
--- a/Template/EDM/bin/tmpFWLite.cc
+++ b/Template/EDM/bin/tmpFWLite.cc
@@ -22,7 +22,7 @@
 #include "FWCore/FWLite/interface/AutoLibraryLoader.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
+#include "FWCore/PythonParameterSet/interface/MakePyBind11ParameterSets.h"
 
 #include <TH1F.h>
 #include <TH2F.h>

--- a/Write/interface/NtuParameterSetWrapper.h
+++ b/Write/interface/NtuParameterSetWrapper.h
@@ -19,7 +19,7 @@
 //------------------------------------
 // Collaborating Class Declarations --
 //------------------------------------
-#include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
+#include "FWCore/PythonParameterSet/interface/MakePyBind11ParameterSets.h"
 
 //---------------
 // C++ Headers --
@@ -38,7 +38,7 @@ class NtuParameterSetWrapper {
    */
   static std::shared_ptr<edm::ParameterSet> readPSetsFrom(
                                             const std::string& fileOrString ) {
-    return edm::readPSetsFrom( fileOrString );
+    return edm::cmspybind11::readPSetsFrom( fileOrString );
   }
 
 };


### PR DESCRIPTION
After the step `NtuAnalysis/uty/makeTemplate.sh test` the resulting analysis code doesn't compile. The error is below. This PR fixes this error.

```
>> Compiling  /afs/cern.ch/work/m/mccauley/CMSSW_10_6_10/src/TESTAnalysis/EDM/bin/testFWLite.cc In file included from /afs/cern.ch/work/m/mccauley/CMSSW_10_6_10/src/TESTAnalysis/EDM/bin/testFWLite.cc:12:
/afs/cern.ch/work/m/mccauley/CMSSW_10_6_10/src/NtuAnalysis/Write/interface/NtuParameterSetWrapper.h:22:10: fatal error: FWCore/PythonParameterSet/interface/MakeParameterSets.h: No such file or directory
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
In file included from /afs/cern.ch/work/m/mccauley/CMSSW_10_6_10/src/TESTAnalysis/EDM/bin/testFWLite.cc:12:
/afs/cern.ch/work/m/mccauley/CMSSW_10_6_10/src/NtuAnalysis/Write/interface/NtuParameterSetWrapper.h:22:10: fatal error: FWCore/PythonParameterSet/interface/MakeParameterSets.h: No such file or directory
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake: *** [config/SCRAM/GMake/Makefile.rules:1733: tmp/slc7_amd64_gcc820/src/TESTAnalysis/EDM/bin/testFWLite/testFWLite.cc.o] Error 1
gmake: *** [There are compilation/build errors. Please see the detail log above.] Error 2
>> Compiling  /afs/cern.ch/work/m/mccauley/CMSSW_10_6_10/src/TESTAnalysis/EDM/bin/testFWLite.cc 
/afs/cern.ch/work/m/mccauley/CMSSW_10_6_10/src/TESTAnalysis/EDM/bin/testFWLite.cc:25:10: fatal error: FWCore/PythonParameterSet/interface/MakeParameterSets.h: No such file or directory
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
/afs/cern.ch/work/m/mccauley/CMSSW_10_6_10/src/TESTAnalysis/EDM/bin/testFWLite.cc:25:10: fatal error: FWCore/PythonParameterSet/interface/MakeParameterSets.h: No such file or directory
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake: *** [config/SCRAM/GMake/Makefile.rules:1733: tmp/slc7_amd64_gcc820/src/TESTAnalysis/EDM/bin/testFWLite/testFWLite.cc.o] Error 1
gmake: *** [There are compilation/build errors. Please see the detail log above.] Error 2
```